### PR TITLE
Add unit test to API package

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -16,26 +16,26 @@ type Config struct {
 type Server struct {
 	config *Config
 	logger *zap.Logger
-	Srv    *http.Server
+	srv    *http.Server
 }
 
 func New(config *Config, logger *zap.Logger) *Server {
 	return &Server{
 		config: config,
 		logger: logger,
-		Srv: &http.Server{
+		srv: &http.Server{
 			Addr: fmt.Sprintf("%s:%d", config.Host, config.Port),
 		},
 	}
 }
 
 func (s *Server) Run(mux *http.ServeMux) error {
-	s.Srv.Handler = mux
+	s.srv.Handler = mux
 	logger := s.logger.Sugar()
 	logger.Infof("API server listening on %s:%d", s.config.Host, s.config.Port)
-	return s.Srv.ListenAndServe()
+	return s.srv.ListenAndServe()
 }
 
 func (s *Server) Shutdown() error {
-	return s.Srv.Shutdown(context.Background())
+	return s.srv.Shutdown(context.Background())
 }

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -1,0 +1,32 @@
+package api_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/ralexstokes/relay-monitor/pkg/api"
+	"go.uber.org/zap"
+)
+
+const (
+	fakeHost = "localhost"
+	fakePort = 1559
+)
+
+func TestNew(t *testing.T) {
+	api.New(&api.Config{}, &zap.Logger{})
+}
+
+func TestRun(t *testing.T) {
+	s := api.New(&api.Config{
+		Host: fakeHost,
+		Port: fakePort,
+	}, zap.NewExample())
+
+	go func() {
+		s.Run(http.NewServeMux())
+	}()
+	if err := s.Shutdown(); err != nil {
+		t.Fatalf("Shutdown failed: %v", err)
+	}
+}


### PR DESCRIPTION
This addresses https://github.com/ralexstokes/relay-monitor/issues/11. 

While trying to figure out the right way to unit test this, I refactored the server slightly to not call `http.ListenAndServer` directly, but instead call it on an `http.Server` object which is a field in the overall `Server` struct. This was based on: https://stackoverflow.com/questions/55699470/how-to-test-refactor-to-test-a-function-that-calls-http-listenandserve. 

I also added a `Shutdown()` function to the `Server` which gives more granular control, and is necessary to get the test to terminate. 