### PR TITLE
refactor codebase to separate collection from analysis from the one monitor component

### DIFF
--- a/cmd/relay-monitor/main.go
+++ b/cmd/relay-monitor/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
 	"os"
@@ -44,5 +45,6 @@ func main() {
 	}
 
 	m := monitor.New(config, zapLogger)
-	m.Run()
+	ctx := context.Background()
+	m.Run(ctx)
 }

--- a/pkg/analysis/analyzer.go
+++ b/pkg/analysis/analyzer.go
@@ -1,0 +1,63 @@
+package analysis
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ralexstokes/relay-monitor/pkg/builder"
+	"github.com/ralexstokes/relay-monitor/pkg/data"
+	"go.uber.org/zap"
+)
+
+type Analyzer struct {
+	logger *zap.Logger
+
+	events <-chan data.Event
+
+	faults     FaultRecord
+	faultsLock sync.Mutex
+}
+
+func NewAnalyzer(logger *zap.Logger, relays []*builder.Client, events <-chan data.Event) *Analyzer {
+	faults := make(FaultRecord)
+	for _, relay := range relays {
+		faults[relay.PublicKey] = &Faults{}
+	}
+	return &Analyzer{
+		logger: logger,
+		events: events,
+		faults: faults,
+	}
+}
+
+func (a *Analyzer) GetFaults() FaultRecord {
+	a.faultsLock.Lock()
+	defer a.faultsLock.Unlock()
+
+	faults := make(FaultRecord)
+	for relay, summary := range a.faults {
+		summary := *summary
+		faults[relay] = &summary
+	}
+
+	return faults
+}
+
+func (a *Analyzer) Run(ctx context.Context) error {
+	logger := a.logger.Sugar()
+
+	for {
+		select {
+		case event := <-a.events:
+			logger.Debugf("got event: %v", event)
+
+			relayID := event.Relay
+			a.faultsLock.Lock()
+			faults := a.faults[relayID]
+			faults.ValidBids += 1
+			a.faultsLock.Unlock()
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}

--- a/pkg/analysis/relay_faults.go
+++ b/pkg/analysis/relay_faults.go
@@ -1,6 +1,10 @@
-package monitor
+package analysis
 
-type RelayFaults struct {
+import "github.com/ralexstokes/relay-monitor/pkg/types"
+
+type FaultRecord = map[types.PublicKey]*Faults
+
+type Faults struct {
 	ValidBids                uint `json:"valid_bids"`
 	MalformedBids            uint `json:"malformed_bids"`
 	ConsensusInvalidBids     uint `json:"consensus_invalid_bids"`

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1,11 +1,16 @@
 package api
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 
+	"github.com/ralexstokes/relay-monitor/pkg/analysis"
 	"go.uber.org/zap"
 )
+
+const GetFaultEndpoint = "/api/v1/relay-monitor/faults"
 
 type Config struct {
 	Host string `yaml:"host"`
@@ -15,18 +20,38 @@ type Config struct {
 type Server struct {
 	config *Config
 	logger *zap.Logger
+
+	analyzer *analysis.Analyzer
 }
 
-func New(config *Config, logger *zap.Logger) *Server {
+func New(config *Config, logger *zap.Logger, analyzer *analysis.Analyzer) *Server {
 	return &Server{
-		config: config,
-		logger: logger,
+		config:   config,
+		logger:   logger,
+		analyzer: analyzer,
 	}
 }
 
-func (s *Server) Run(mux *http.ServeMux) error {
+func (s *Server) handleFaultsRequest(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	encoder := json.NewEncoder(w)
+
+	faults := s.analyzer.GetFaults()
+	err := encoder.Encode(faults)
+	if err != nil {
+		logger := s.logger.Sugar()
+		logger.Errorw("could not encode relay faults", "error", err)
+	}
+}
+
+func (s *Server) Run(ctx context.Context) error {
 	logger := s.logger.Sugar()
 	host := fmt.Sprintf("%s:%d", s.config.Host, s.config.Port)
 	logger.Infof("API server listening on %s", host)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(GetFaultEndpoint, s.handleFaultsRequest)
 	return http.ListenAndServe(host, mux)
 }

--- a/pkg/builder/client.go
+++ b/pkg/builder/client.go
@@ -14,17 +14,13 @@ import (
 const clientTimeoutSec = 2
 
 type Client struct {
-	endpoint string
-	identity string
-	client   http.Client
+	endpoint  string
+	PublicKey types.PublicKey
+	client    http.Client
 }
 
 func (c *Client) String() string {
-	return c.ID()
-}
-
-func (c *Client) ID() string {
-	return c.identity
+	return c.PublicKey.String()
 }
 
 func NewClient(endpoint string) (*Client, error) {
@@ -33,15 +29,20 @@ func NewClient(endpoint string) (*Client, error) {
 		return nil, err
 	}
 
-	publicKey := u.User.Username()
+	publicKeyStr := u.User.Username()
+	var publicKey types.PublicKey
+	err = publicKey.UnmarshalText([]byte(publicKeyStr))
+	if err != nil {
+		return nil, err
+	}
 
 	client := http.Client{
 		Timeout: clientTimeoutSec * time.Second,
 	}
 	return &Client{
-		endpoint: endpoint,
-		identity: publicKey,
-		client:   client,
+		endpoint:  endpoint,
+		PublicKey: publicKey,
+		client:    client,
 	}, nil
 }
 

--- a/pkg/builder/client_test.go
+++ b/pkg/builder/client_test.go
@@ -8,18 +8,20 @@ import (
 )
 
 const (
-	exampleRelayURL = "https://builder-relay-sepolia.flashbots.net"
+	exampleRelayURL = "https://0x845bd072b7cd566f02faeb0a4033ce9399e42839ced64e8b2adcfc859ed1e8e1a5a293336a49feac6d9a5edb779be53a@builder-relay-sepolia.flashbots.net"
 )
 
 func TestClientStatus(t *testing.T) {
 	c, err := builder.NewClient(exampleRelayURL)
 	if err != nil {
 		t.Error(err)
+		return
 	}
 
 	err = c.GetStatus()
 	if err != nil {
 		t.Error(err)
+		return
 	}
 }
 
@@ -27,10 +29,12 @@ func TestClientBid(t *testing.T) {
 	c, err := builder.NewClient(exampleRelayURL)
 	if err != nil {
 		t.Error(err)
+		return
 	}
 
 	_, err = c.GetBid(100, types.Hash{}, types.PublicKey{})
 	if err != nil {
 		t.Error(err)
+		return
 	}
 }

--- a/pkg/consensus/clock.go
+++ b/pkg/consensus/clock.go
@@ -24,7 +24,7 @@ func (c *Clock) slotInSeconds(slot types.Slot) int64 {
 	return int64(slot*c.slotsPerSecond + c.genesisTime)
 }
 
-func (c *Clock) currentSlot(currentTime int64) types.Slot {
+func (c *Clock) CurrentSlot(currentTime int64) types.Slot {
 	diff := currentTime - int64(c.genesisTime)
 	// TODO better handling of pre-genesis
 	if diff < 0 {
@@ -38,7 +38,7 @@ func (c *Clock) TickSlots() chan types.Slot {
 	go func() {
 		for {
 			now := time.Now().Unix()
-			currentSlot := c.currentSlot(now)
+			currentSlot := c.CurrentSlot(now)
 			ch <- currentSlot
 			nextSlot := currentSlot + 1
 			nextSlotStart := c.slotInSeconds(nextSlot)

--- a/pkg/data/collector.go
+++ b/pkg/data/collector.go
@@ -1,0 +1,139 @@
+package data
+
+import (
+	"context"
+	"time"
+
+	"github.com/ralexstokes/relay-monitor/pkg/builder"
+	"github.com/ralexstokes/relay-monitor/pkg/consensus"
+	"go.uber.org/zap"
+)
+
+type Collector struct {
+	logger          *zap.Logger
+	relays          []*builder.Client
+	clock           *consensus.Clock
+	consensusClient *consensus.Client
+	events          chan<- Event
+}
+
+func NewCollector(zapLogger *zap.Logger, relays []*builder.Client, clock *consensus.Clock, consensusClient *consensus.Client, events chan<- Event) *Collector {
+	return &Collector{
+		logger:          zapLogger,
+		relays:          relays,
+		clock:           clock,
+		consensusClient: consensusClient,
+		events:          events,
+	}
+}
+
+func (c *Collector) collectFromRelay(ctx context.Context, relay *builder.Client) {
+	logger := c.logger.Sugar()
+
+	relayID := relay.PublicKey
+	logger.Infof("monitoring relay %s", relayID)
+
+	slots := c.clock.TickSlots()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case slot := <-slots:
+			parentHash, err := c.consensusClient.GetParentHash(slot)
+			if err != nil {
+				logger.Warnw("error fetching bid", "error", err)
+				continue
+			}
+			publicKey, err := c.consensusClient.GetProposerPublicKey(slot)
+			if err != nil {
+				logger.Warnw("error fetching bid", "error", err)
+				continue
+			}
+			bid, err := relay.GetBid(slot, parentHash, *publicKey)
+			if err != nil {
+				logger.Warnw("could not get bid from relay", "error", err, "relayPublicKey", relayID, "slot", slot, "parentHash", parentHash, "proposer", publicKey)
+			} else if bid != nil {
+				logger.Debugw("got bid", "value", bid.Message.Value, "header", bid.Message.Header, "publicKey", bid.Message.Pubkey, "id", relayID)
+				c.events <- Event{Relay: relayID, Bid: bid}
+			}
+		}
+	}
+}
+
+func (c *Collector) runSlotTasks(ctx context.Context) {
+	logger := c.logger.Sugar()
+
+	// Load data for the previous slot
+	now := time.Now().Unix()
+	currentSlot := c.clock.CurrentSlot(now)
+	_, err := c.consensusClient.FetchExecutionHash(currentSlot - 1)
+	if err != nil {
+		logger.Warnf("could not fetch latest execution hash for slot %d: %v", currentSlot, err)
+	}
+
+	// Load data for the current slot
+	_, err = c.consensusClient.FetchExecutionHash(currentSlot)
+	if err != nil {
+		logger.Warnf("could not fetch latest execution hash for slot %d: %v", currentSlot, err)
+	}
+
+	heads := c.consensusClient.StreamHeads()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case head := <-heads:
+			_, err := c.consensusClient.FetchExecutionHash(head.Slot)
+			if err != nil {
+				logger.Warnf("could not fetch latest execution hash for slot %d: %v", head.Slot, err)
+			}
+		}
+	}
+}
+
+func (c *Collector) runEpochTasks(ctx context.Context) {
+	logger := c.logger.Sugar()
+
+	epochs := c.clock.TickEpochs()
+
+	// Load data for the current epoch
+	epoch := <-epochs
+	err := c.consensusClient.LoadData(epoch)
+	if err != nil {
+		logger.Warnf("could not load consensus state for epoch %d: %v", epoch, err)
+	}
+
+	// Load data for the next epoch, as we will typically do
+	err = c.consensusClient.LoadData(epoch + 1)
+	if err != nil {
+		logger.Warnf("could not load consensus state for epoch %d: %v", epoch, err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case epoch := <-epochs:
+			err := c.consensusClient.LoadData(epoch + 1)
+			if err != nil {
+				logger.Warnf("could not load consensus state for epoch %d: %v", epoch, err)
+			}
+		}
+	}
+}
+
+func (c *Collector) collectConsensusData(ctx context.Context) {
+	go c.runSlotTasks(ctx)
+	go c.runEpochTasks(ctx)
+
+}
+
+func (c *Collector) Run(ctx context.Context) error {
+	for _, relay := range c.relays {
+		go c.collectFromRelay(ctx, relay)
+	}
+	go c.collectConsensusData(ctx)
+
+	<-ctx.Done()
+	return nil
+}

--- a/pkg/data/event.go
+++ b/pkg/data/event.go
@@ -1,0 +1,8 @@
+package data
+
+import "github.com/ralexstokes/relay-monitor/pkg/types"
+
+type Event struct {
+	Relay types.PublicKey
+	Bid   *types.Bid
+}

--- a/pkg/monitor/config.go
+++ b/pkg/monitor/config.go
@@ -1,0 +1,21 @@
+package monitor
+
+import "github.com/ralexstokes/relay-monitor/pkg/api"
+
+type NetworkConfig struct {
+	Name           string `yaml:"name"`
+	GenesisTime    uint64 `yaml:"genesis_time"`
+	SlotsPerSecond uint64 `yaml:"slots_per_second"`
+	SlotsPerEpoch  uint64 `yaml:"slots_per_epoch"`
+}
+
+type ConsensusConfig struct {
+	Endpoint string `yaml:"endpoint"`
+}
+
+type Config struct {
+	Network   *NetworkConfig   `yaml:"network"`
+	Consensus *ConsensusConfig `yaml:"consensus"`
+	Relays    []string         `yaml:"relays"`
+	Api       *api.Config      `yaml:"api"`
+}


### PR DESCRIPTION
thanks to @rauljordan and @terencechain for feedback!

this PR has many changes but generally:

- migrates to a `context.Context` based orchestration pattern
- separates out a "collection" component that gathers all the potential data we want to derive monitor faults
- separates out an "analyzer" component that waits for events from the collector and then adjusts the fault counts accordingly
- separates out an API server that uniquely manages the HTTP interface to this service