### PR TITLE
Update client.go timeout

### DIFF
--- a/pkg/consensus/client.go
+++ b/pkg/consensus/client.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	clientTimeoutSec = 5
+	clientTimeoutSec = 30
 	cacheSize        = 128
 )
 


### PR DESCRIPTION
Specifically, the `FetchValidators` request can take quite a long time.