### PR TITLE
feat: add endpoint to relay data in fault response

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,14 +149,19 @@ NOTE: if neither parameter is provided, the response will be `256` epochs behind
   },
   "data": {
     "0x845bd072b7cd566f02faeb0a4033ce9399e42839ced64e8b2adcfc859ed1e8e1a5a293336a49feac6d9a5edb779be53a": {
-      "total_bids": 1153,
-      "malformed_bids": 0,
-      "consensus_invalid_bids": 1,
-      "payment_invalid_bids": 12,
-      "ignored_preferences_bids": 5,
-      "malformed_payloads": 0,
-      "consensus_invalid_payloads": 1,
-      "unavailable_payloads": 10
+        "stats": {
+            "total_bids": 1153,
+            "malformed_bids": 0,
+            "consensus_invalid_bids": 1,
+            "payment_invalid_bids": 12,
+            "ignored_preferences_bids": 5,
+            "malformed_payloads": 0,
+            "consensus_invalid_payloads": 1,
+            "unavailable_payloads": 10
+        },
+        "misc": {
+            "endpoint": "builder-relay-sepolia.flashbots.net"
+        }
     }
   }
 }

--- a/pkg/analysis/analyzer.go
+++ b/pkg/analysis/analyzer.go
@@ -25,7 +25,12 @@ type Analyzer struct {
 func NewAnalyzer(logger *zap.Logger, relays []*builder.Client, events <-chan data.Event, store store.Storer) *Analyzer {
 	faults := make(FaultRecord)
 	for _, relay := range relays {
-		faults[relay.PublicKey] = &Faults{}
+		faults[relay.PublicKey] = &Faults{
+			Stats: &FaultStats{},
+			Misc: &Misc{
+				Endpoint: relay.Hostname(),
+			},
+		}
 	}
 	return &Analyzer{
 		logger: logger,
@@ -65,7 +70,7 @@ func (a *Analyzer) processBid(ctx context.Context, event *data.BidEvent) {
 	relayID := bidCtx.RelayPublicKey
 	a.faultsLock.Lock()
 	faults := a.faults[relayID]
-	faults.TotalBids += 1
+	faults.Stats.TotalBids += 1
 	a.faultsLock.Unlock()
 }
 

--- a/pkg/analysis/relay_faults.go
+++ b/pkg/analysis/relay_faults.go
@@ -5,6 +5,11 @@ import "github.com/ralexstokes/relay-monitor/pkg/types"
 type FaultRecord = map[types.PublicKey]*Faults
 
 type Faults struct {
+	Stats *FaultStats `json:"stats"`
+	Misc  *Misc       `json:"misc"`
+}
+
+type FaultStats struct {
 	TotalBids                uint `json:"total_bids"`
 	MalformedBids            uint `json:"malformed_bids"`
 	ConsensusInvalidBids     uint `json:"consensus_invalid_bids"`
@@ -13,4 +18,8 @@ type Faults struct {
 	MalformedPayloads        uint `json:"malformed_payloads"`
 	ConsensusInvalidPayloads uint `json:"consensus_invalid_payloads"`
 	UnavailablePayloads      uint `json:"unavailable_payloads"`
+}
+
+type Misc struct {
+	Endpoint string `json:"endpoint"`
 }

--- a/pkg/builder/client.go
+++ b/pkg/builder/client.go
@@ -15,8 +15,13 @@ const clientTimeoutSec = 2
 
 type Client struct {
 	endpoint  string
+	hostname  string
 	PublicKey types.PublicKey
 	client    http.Client
+}
+
+func (c *Client) Hostname() string {
+	return c.hostname
 }
 
 func (c *Client) String() string {
@@ -28,6 +33,8 @@ func NewClient(endpoint string) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	hostname := u.Hostname()
 
 	publicKeyStr := u.User.Username()
 	var publicKey types.PublicKey
@@ -41,6 +48,7 @@ func NewClient(endpoint string) (*Client, error) {
 	}
 	return &Client{
 		endpoint:  endpoint,
+		hostname:  hostname,
 		PublicKey: publicKey,
 		client:    client,
 	}, nil


### PR DESCRIPTION
Implements #39. I made a change to have the returned fault data to be split up into `stats` and `misc` under which the endpoint now goes and in future perhaps other misc info about a relay. Figured might be good to keep these two separate since they're semantically different as opposed to mixing stats with this quite static field. thoughts?