### PR TITLE
feat: basic validator registrations stats endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ NOTE: if neither parameter is provided, the response will be `256` epochs behind
 }
 ```
 
-### GET `/monitor/v1/validators/`
+### GET `/monitor/v1/validators`
 
 Exposes a stats counter for unique validators that the relay monitor has processed registrations for. A unique registration is identified and stored by the relay monitor via the provided validator `"pubkey"`. Registrations are submitted via [the exposed `registerValidator`](#post-ethv1buildervalidators) endpoint.
 

--- a/README.md
+++ b/README.md
@@ -166,3 +166,27 @@ NOTE: if neither parameter is provided, the response will be `256` epochs behind
   }
 }
 ```
+
+### GET `/monitor/v1/validators/`
+
+Exposes a stats counter for unique validators that the relay monitor has processed registrations for. A unique registration is identified and stored by the relay monitor via the provided validator `"pubkey"`. Registrations are submitted via [the exposed `registerValidator`](#post-ethv1buildervalidators) endpoint.
+
+#### Example response:
+
+```json
+{
+    "count": 1
+}
+```
+
+### GET `/monitor/v1/validators/registrations`
+
+Exposes a stats counter for the total number of validator registrations that the relay monitor has processed. A validator can, and is expected to, update block building preferences via [the exposed `registerValidator`](#post-ethv1buildervalidators) endpoint.
+
+#### Example response:
+
+```json
+{
+    "count": 10
+}
+```

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -24,6 +24,10 @@ const (
 	RegisterValidatorEndpoint       = "/eth/v1/builder/validators"
 	PostAuctionTranscriptEndpoint   = "/monitor/v1/transcript"
 	DefaultEpochSpanForFaultsWindow = 256
+
+	// Validator metrics endpoints.
+	GetValidatorsEndpoint              = "/monitor/v1/validators/"
+	GetValidatorsRegistrationsEndpoint = "/monitor/v1/validators/registrations"
 )
 
 type Config struct {
@@ -39,6 +43,14 @@ type Span struct {
 type FaultsResponse struct {
 	Span                 Span `json:"span"`
 	analysis.FaultRecord `json:"data"`
+}
+
+type CountResponse struct {
+	Count int `json:"count"`
+}
+
+type MessageResponse struct {
+	Message string `json:"message"`
 }
 
 type Server struct {
@@ -119,7 +131,7 @@ func (s *Server) handleFaultsRequest(w http.ResponseWriter, r *http.Request) {
 		startEpochValue, err := strconv.ParseUint(startEpochStr, 10, 64)
 		if err != nil {
 			logger.Errorw("error parsing query param for faults request", "err", err, "startEpoch", startEpochStr)
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			s.respondError(w, http.StatusBadRequest, err.Error())
 			return
 		}
 		epoch := types.Epoch(startEpochValue)
@@ -132,7 +144,7 @@ func (s *Server) handleFaultsRequest(w http.ResponseWriter, r *http.Request) {
 		endEpochValue, err := strconv.ParseUint(endEpochStr, 10, 64)
 		if err != nil {
 			logger.Errorw("error parsing query param for faults request", "err", err, "endEpoch", endEpochStr)
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			s.respondError(w, http.StatusBadRequest, err.Error())
 			return
 		}
 		epoch := types.Epoch(endEpochValue)
@@ -145,7 +157,7 @@ func (s *Server) handleFaultsRequest(w http.ResponseWriter, r *http.Request) {
 		epochSpanValue, err := strconv.ParseUint(epochSpanForFaultsWindow, 10, 64)
 		if err != nil {
 			logger.Errorw("error parsing query param for faults request", "err", err, "epochSpan", epochSpanForFaultsWindow)
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			s.respondError(w, http.StatusBadRequest, err.Error())
 			return
 		}
 		epochSpanRequest = types.Epoch(epochSpanValue)
@@ -155,9 +167,6 @@ func (s *Server) handleFaultsRequest(w http.ResponseWriter, r *http.Request) {
 	startEpoch, endEpoch := computeSpanFromRequest(startEpochRequest, endEpochRequest, epochSpanRequest, currentEpoch)
 	faults := s.analyzer.GetFaults(startEpoch, endEpoch)
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-
 	response := FaultsResponse{
 		Span: Span{
 			Start: startEpoch,
@@ -165,13 +174,7 @@ func (s *Server) handleFaultsRequest(w http.ResponseWriter, r *http.Request) {
 		},
 		FaultRecord: faults,
 	}
-	encoder := json.NewEncoder(w)
-	encoder.SetIndent("", "  ")
-	err := encoder.Encode(response)
-	if err != nil {
-		logger.Errorw("could not encode relay faults", "error", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
+	s.respondOK(w, response)
 }
 
 func (s *Server) validateRegistrationTimestamp(registration, currentRegistration *types.SignedValidatorRegistration) error {
@@ -242,6 +245,67 @@ type apiError struct {
 	Message string `json:"message"`
 }
 
+func (s *Server) respondError(w http.ResponseWriter, code int, message string) {
+	logger := s.logger.Sugar()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	response := apiError{code, message}
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		logger.Errorw("couldn't write error response", "response", response, "error", err)
+		http.Error(w, "", http.StatusInternalServerError)
+	}
+}
+
+func (s *Server) respondOK(w http.ResponseWriter, response any) {
+	logger := s.logger.Sugar()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		logger.Errorw("couldn't write OK response", "response", response, "error", err)
+		http.Error(w, "", http.StatusInternalServerError)
+	}
+}
+
+func (s *Server) handleRoot(w http.ResponseWriter, req *http.Request) {
+	s.respondOK(w, MessageResponse{
+		Message: "Relay Monitor API",
+	})
+}
+
+func (s *Server) handleCountValidators(w http.ResponseWriter, r *http.Request) {
+	logger := s.logger.Sugar()
+
+	validators, err := s.store.GetCountValidators(context.Background())
+	if err != nil {
+		s.respondError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	response := CountResponse{
+		Count: validators,
+	}
+	logger.Debugw("processed request for validators", "count", response.Count)
+
+	s.respondOK(w, response)
+}
+
+func (s *Server) handleCountValidatorsRegistrations(w http.ResponseWriter, r *http.Request) {
+	logger := s.logger.Sugar()
+
+	registrations, err := s.store.GetCountValidatorsRegistrations(context.Background())
+	if err != nil {
+		s.respondError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	response := CountResponse{
+		Count: registrations,
+	}
+	logger.Debugw("processed request for validators registrations", "count", response.Count)
+
+	s.respondOK(w, response)
+}
+
 func (s *Server) handleRegisterValidator(w http.ResponseWriter, r *http.Request) {
 	logger := s.logger.Sugar()
 	ctx := context.Background()
@@ -250,7 +314,7 @@ func (s *Server) handleRegisterValidator(w http.ResponseWriter, r *http.Request)
 	err := json.NewDecoder(r.Body).Decode(&registrations)
 	if err != nil {
 		logger.Warn("could not decode signed validator registration")
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		s.respondError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -258,25 +322,13 @@ func (s *Server) handleRegisterValidator(w http.ResponseWriter, r *http.Request)
 		currentRegistration, err := store.GetLatestValidatorRegistration(ctx, s.store, &registration.Message.Pubkey)
 		if err != nil {
 			logger.Warnw("could not get registrations for validator", "error", err, "registration", registration)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			s.respondError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
 		err = s.validateRegistration(&registration, currentRegistration)
 		if err != nil {
 			logger.Warnw("invalid validator registration in batch", "registration", registration, "error", err)
-			w.WriteHeader(http.StatusBadRequest)
-			w.Header().Set("Content-Type", "application/json")
-			response := apiError{
-				Code:    http.StatusBadRequest,
-				Message: err.Error(),
-			}
-			encoder := json.NewEncoder(w)
-			err := encoder.Encode(response)
-			if err != nil {
-				logger.Warnw("could not send API error", "error", err)
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
+			s.respondError(w, http.StatusBadRequest, err.Error())
 			return
 		}
 	}
@@ -297,7 +349,7 @@ func (s *Server) handleAuctionTranscript(w http.ResponseWriter, r *http.Request)
 	err := json.NewDecoder(r.Body).Decode(&transcript)
 	if err != nil {
 		logger.Warn("could not decode auction transcript")
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		s.respondError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -318,9 +370,13 @@ func (s *Server) Run(ctx context.Context) error {
 	logger.Infof("API server listening on %s", host)
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/", get(s.handleFaultsRequest))
+	mux.HandleFunc("/", get(s.handleRoot))
 	mux.HandleFunc(GetFaultEndpoint, get(s.handleFaultsRequest))
 	mux.HandleFunc(RegisterValidatorEndpoint, post(s.handleRegisterValidator))
+
+	mux.HandleFunc(GetValidatorsEndpoint, get(s.handleCountValidators))
+	mux.HandleFunc(GetValidatorsRegistrationsEndpoint, get(s.handleCountValidatorsRegistrations))
+
 	mux.HandleFunc(PostAuctionTranscriptEndpoint, post(s.handleAuctionTranscript))
 	return http.ListenAndServe(host, mux)
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -15,6 +15,10 @@ type Storer interface {
 	GetBid(context.Context, *types.BidContext) (*types.Bid, error)
 	// `GetValidatorRegistrations` returns all known registrations for the validator's public key, sorted by timestamp (increasing).
 	GetValidatorRegistrations(context.Context, *types.PublicKey) ([]types.SignedValidatorRegistration, error)
+	// `GetCountValidatorsRegistrations`returns the total number of valid registrations processed.
+	GetCountValidatorsRegistrations(ctx context.Context) (int, error)
+	// `GetCountValidators`returns the number of validators that have successfully submitted at least one registration.
+	GetCountValidators(ctx context.Context) (int, error)
 }
 
 type MemoryStore struct {
@@ -59,4 +63,16 @@ func (s *MemoryStore) PutAcceptance(ctx context.Context, bidCtx *types.BidContex
 
 func (s *MemoryStore) GetValidatorRegistrations(ctx context.Context, publicKey *types.PublicKey) ([]types.SignedValidatorRegistration, error) {
 	return s.registrations[*publicKey], nil
+}
+
+func (s *MemoryStore) GetCountValidatorsRegistrations(ctx context.Context) (int, error) {
+	var totalRegistrations int
+	for _, signedRegistrations := range s.registrations {
+		totalRegistrations += len(signedRegistrations)
+	}
+	return totalRegistrations, nil
+}
+
+func (s *MemoryStore) GetCountValidators(ctx context.Context) (int, error) {
+	return len(s.registrations), nil
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -16,9 +16,9 @@ type Storer interface {
 	// `GetValidatorRegistrations` returns all known registrations for the validator's public key, sorted by timestamp (increasing).
 	GetValidatorRegistrations(context.Context, *types.PublicKey) ([]types.SignedValidatorRegistration, error)
 	// `GetCountValidatorsRegistrations`returns the total number of valid registrations processed.
-	GetCountValidatorsRegistrations(ctx context.Context) (int, error)
+	GetCountValidatorsRegistrations(ctx context.Context) (uint, error)
 	// `GetCountValidators`returns the number of validators that have successfully submitted at least one registration.
-	GetCountValidators(ctx context.Context) (int, error)
+	GetCountValidators(ctx context.Context) (uint, error)
 }
 
 type MemoryStore struct {
@@ -65,14 +65,14 @@ func (s *MemoryStore) GetValidatorRegistrations(ctx context.Context, publicKey *
 	return s.registrations[*publicKey], nil
 }
 
-func (s *MemoryStore) GetCountValidatorsRegistrations(ctx context.Context) (int, error) {
-	var totalRegistrations int
+func (s *MemoryStore) GetCountValidatorsRegistrations(ctx context.Context) (uint, error) {
+	var totalRegistrations uint
 	for _, signedRegistrations := range s.registrations {
-		totalRegistrations += len(signedRegistrations)
+		totalRegistrations += uint(len(signedRegistrations))
 	}
 	return totalRegistrations, nil
 }
 
-func (s *MemoryStore) GetCountValidators(ctx context.Context) (int, error) {
-	return len(s.registrations), nil
+func (s *MemoryStore) GetCountValidators(ctx context.Context) (uint, error) {
+	return uint(len(s.registrations)), nil
 }


### PR DESCRIPTION
Implements #38, specifically just some basic metrics on processed validator registrations. So far we have two endpoints for
1) count of validators
2) total count of registrations processed across all validators

Also rewrites a bunch of the route handling / response writing code to dedup a bit and have for re-use on other endpoints, using the functions from `mev-boost` as inspiration, e.g. [these two](https://github.com/flashbots/mev-boost/blob/fd972dda9546847627b533f24f071ae75063b2f8/server/service.go#L120-L137).